### PR TITLE
Teensy encoder fusion

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "files.associations": {
+        "iosfwd": "cpp",
+        "istream": "cpp",
+        "ostream": "cpp",
+        "streambuf": "cpp",
+        "xiosbase": "cpp",
+        "xstring": "cpp"
+    }
+}

--- a/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
+++ b/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
@@ -13,6 +13,7 @@
 #include <sensor_msgs/Temperature.h>
 #include <std_srvs/Trigger.h>
 #include <std_msgs/UInt8.h>
+#include <std_msgs/Int16MultiArray.h>
 #include <diagnostic_msgs/DiagnosticStatus.h>
 #include <diagnostic_msgs/DiagnosticArray.h>
 #include <diagnostic_msgs/KeyValue.h>
@@ -266,7 +267,7 @@ class BNO055I2CActivity {
     std::string param_frame_id;
     std::string param_device;
     int param_address;
-    int param_enc;
+    int param_enc_addr;
 
     // ROS node handles
     ros::NodeHandle nh;

--- a/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
+++ b/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
@@ -25,6 +25,8 @@
 #define BNO055_ADDRESS_A 0x28 // default
 #define BNO055_ADDRESS_B 0x29
 
+#define TEENSY_ENCODER_ADDR 0x30 // set in Teensy sketch
+
 #define BNO055_CHIP_ID_ADDR 0x00
 #define BNO055_ACCEL_REV_ID_ADDR 0x01
 #define BNO055_MAG_REV_ID_ADDR 0x02
@@ -231,6 +233,15 @@ typedef struct {
   uint8_t system_error_code;
 } IMURecord;
 
+// Struct for Encoder count. 
+// Not sure how the byte packing will work - it's stored Big Endian on the Teensy side
+// Have to pack High Byte and Low Byte in python
+typedef struct{
+  int16_t left_encoder_count;
+  int16_t right_encoder_count;
+
+} EncRecord;
+
 class BNO055I2CActivity {
   public:
     BNO055I2CActivity(ros::NodeHandle &_nh, ros::NodeHandle &_nh_priv);
@@ -248,12 +259,14 @@ class BNO055I2CActivity {
     // class variables
     uint32_t seq = 0;
     int file;
+    int enc_file;
     diagnostic_msgs::DiagnosticStatus current_status;
 
     // ROS parameters
     std::string param_frame_id;
     std::string param_device;
     int param_address;
+    int param_enc;
 
     // ROS node handles
     ros::NodeHandle nh;
@@ -265,6 +278,7 @@ class BNO055I2CActivity {
     ros::Publisher pub_mag;
     ros::Publisher pub_temp;
     ros::Publisher pub_status;
+    ros::Publisdher pub_enc; // publisher for encoder data
 
     // ROS subscribers
     ros::ServiceServer service_calibrate;

--- a/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
+++ b/imu_bno055/include/imu_bno055/bno055_i2c_activity.h
@@ -278,7 +278,7 @@ class BNO055I2CActivity {
     ros::Publisher pub_mag;
     ros::Publisher pub_temp;
     ros::Publisher pub_status;
-    ros::Publisdher pub_enc; // publisher for encoder data
+    ros::Publisher pub_enc; // publisher for encoder data
 
     // ROS subscribers
     ros::ServiceServer service_calibrate;


### PR DESCRIPTION
This fork adds i2C handling of encoder counts from a Teensy running teensy-realtime-master. i2c Slave address of the Teensy should be set to 0x30.

Changes to: 
bno055_i2c_activity.h
bno055_i2c_activity.cpp
